### PR TITLE
Add ability to do a fast filtering pass before parsing wikitext

### DIFF
--- a/articlequality/extractors/extractor.py
+++ b/articlequality/extractors/extractor.py
@@ -147,6 +147,10 @@ class TemplateExtractor(Extractor):
     def __init__(self, *args, from_template, **kwargs):
         self.from_template = from_template
 
+        if 'filter_text' in kwargs:
+            self.filter_text = kwargs.get('filter_text')
+            kwargs.pop('filter_text', None)
+
         super().__init__(*args, **kwargs)
 
     def extract_labels(self, text):
@@ -160,6 +164,13 @@ class TemplateExtractor(Extractor):
         :Returns:
             An iterator over (project, label) pairs
         """
+        # filter_text is an initial fast pass to weed out wikitext that
+        # can't contain the template (eg. because the template name
+        # never appears)
+        if hasattr(self, 'filter_text'):
+            if not self.filter_text(text):
+                return
+
         parsed_text = mwp.parse(text)
         templates = parsed_text.filter_templates()
         for template in templates:

--- a/articlequality/extractors/svwiki.py
+++ b/articlequality/extractors/svwiki.py
@@ -1,0 +1,42 @@
+import logging
+import re
+import sys
+
+from .extractor import TemplateExtractor
+
+logger = logging.getLogger(__name__)
+
+PROJECT_NAME = "wikiproject"
+TEMPLATE_MATCHES = [
+    ("u", re.compile(r"Utmärkt", re.I)),        # featured article
+    ("b", re.compile(r"Bra", re.I)),            # good article
+    ("r", re.compile(r"Rekommenderad", re.I)),  # B class
+    ("s", re.compile(r"stub", re.I)),           # stub
+]
+
+
+def filter_text(text):
+    return re.search(r'(utmärkt|bra|rekommenderad|stub)', text, re.I)
+
+
+def from_template(template):
+    template_name = str(template.name).lower().strip()
+
+    for label, regex in TEMPLATE_MATCHES:
+        if regex.match(template_name):
+            return PROJECT_NAME, label
+
+
+sys.modules[__name__] = TemplateExtractor(
+    __name__,
+    doc="""
+articlequality.extractors.svwiki
++++++++++++++++++++++++++++
+
+This extractor looks for instances of templates on article pages
+(namespace =0 ) with names "Utmärkt", "Bra", "Rekommenderad",
+or containing "stub". All `project` s are hard-coded to "wikiproject"
+""",
+    namespaces={0},
+    from_template=from_template,
+    filter_text=filter_text)


### PR DESCRIPTION
If the template name is nowhere to be seen in the unparsed wikitext, the template can't be in the wikitext. Based on this assumption, this new feature allows template extraction to be much faster.