### PR TITLE
Retrains enwiki model with new features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   - pip install -r requirements.txt
   - python setup.py install
   - pip install codecov
+  - pip install pytest
   - pip install flake8
   - python -m nltk.downloader stopwords
 

--- a/model_info/enwiki.nettrom_wp10.md
+++ b/model_info/enwiki.nettrom_wp10.md
@@ -1,85 +1,85 @@
 Model Information:
 	 - type: GradientBoosting
 	 - version: 0.8.1
-	 - params: {'min_impurity_split': None, 'random_state': None, 'max_leaf_nodes': None, 'population_rates': None, 'loss': 'deviance', 'labels': ['Stub', 'Start', 'C', 'B', 'GA', 'FA'], 'verbose': 0, 'criterion': 'friedman_mse', 'init': None, 'presort': 'auto', 'max_depth': 7, 'learning_rate': 0.01, 'subsample': 1.0, 'min_weight_fraction_leaf': 0.0, 'min_samples_leaf': 1, 'min_impurity_decrease': 0.0, 'warm_start': False, 'max_features': 'log2', 'center': True, 'min_samples_split': 2, 'n_estimators': 500, 'multilabel': False, 'label_weights': None, 'scale': True}
+	 - params: {'max_features': 'log2', 'min_impurity_split': None, 'loss': 'deviance', 'min_samples_leaf': 1, 'subsample': 1.0, 'random_state': None, 'min_samples_split': 2, 'warm_start': False, 'labels': ['Stub', 'Start', 'C', 'B', 'GA', 'FA'], 'criterion': 'friedman_mse', 'scale': True, 'min_weight_fraction_leaf': 0.0, 'multilabel': False, 'presort': 'auto', 'min_impurity_decrease': 0.0, 'verbose': 0, 'population_rates': None, 'n_estimators': 500, 'learning_rate': 0.01, 'label_weights': None, 'max_leaf_nodes': None, 'center': True, 'max_depth': 7, 'init': None}
 	Environment:
-	 - revscoring_version: '2.3.3'
-	 - platform: 'Linux-4.9.0-8-amd64-x86_64-with-debian-9.5'
+	 - revscoring_version: '2.4.0'
+	 - platform: 'Linux-4.9.0-9-amd64-x86_64-with-debian-9.9'
 	 - machine: 'x86_64'
-	 - version: '#1 SMP Debian 4.9.110-3+deb9u6 (2018-10-08)'
+	 - version: '#1 SMP Debian 4.9.168-1+deb9u2 (2019-05-13)'
 	 - system: 'Linux'
 	 - processor: ''
-	 - python_build: ('default', 'Jan 19 2017 14:11:04')
-	 - python_compiler: 'GCC 6.3.0 20170118'
+	 - python_build: ('default', 'Sep 27 2018 17:25:39')
+	 - python_compiler: 'GCC 6.3.0 20170516'
 	 - python_branch: ''
 	 - python_implementation: 'CPython'
 	 - python_revision: ''
 	 - python_version: '3.5.3'
-	 - release: '4.9.0-8-amd64'
+	 - release: '4.9.0-9-amd64'
 	
 	Statistics:
-	counts (n=32415):
+	counts (n=32402):
 		label       n         ~Stub    ~Start    ~C    ~B    ~GA    ~FA
 		-------  ----  ---  -------  --------  ----  ----  -----  -----
-		'Stub'   5483  -->     4654       786    24    18      1      0
-		'Start'  5473  -->      716      3514   832   346     61      4
-		'C'      5483  -->       68       987  2707  1063    558    100
-		'B'      5485  -->       38       660  1377  2169    880    361
-		'GA'     5495  -->        3        42   361   344   3447   1298
-		'FA'     4996  -->        1         2    23   231    949   3790
+		'Stub'   5477  -->     4682       758    23    13      1      0
+		'Start'  5469  -->      712      3517   835   338     64      3
+		'C'      5480  -->       65       996  2726  1048    548     97
+		'B'      5485  -->       33       673  1407  2142    873    357
+		'GA'     5495  -->        3        42   324   330   3502   1294
+		'FA'     4996  -->        1         2    25   242    917   3809
 	rates:
 		              'Stub'    'Start'    'C'    'B'    'GA'    'FA'
 		----------  --------  ---------  -----  -----  ------  ------
 		sample         0.169      0.169  0.169  0.169    0.17   0.154
 		population     0.576      0.322  0.054  0.035    0.01   0.003
-	match_rate (micro=0.387, macro=0.19):
-		   FA      C    Start     GA    Stub      B
-		-----  -----  -------  -----  ------  -----
-		0.066  0.119    0.269  0.096   0.502  0.085
-	filter_rate (micro=0.613, macro=0.81):
-		   FA      C    Start     GA    Stub      B
-		-----  -----  -------  -----  ------  -----
-		0.934  0.881    0.731  0.904   0.498  0.915
-	recall (micro=0.745, macro=0.628):
-		   FA      C    Start     GA    Stub      B
-		-----  -----  -------  -----  ------  -----
-		0.759  0.494    0.642  0.627   0.849  0.395
-	!recall (micro=0.944, macro=0.925):
-		   FA      C    Start     GA    Stub      B
-		-----  -----  -------  -----  ------  -----
-		0.936  0.903    0.908  0.909   0.969  0.926
+	match_rate (micro=0.389, macro=0.19):
+		  Stub      C     GA    Start     FA      B
+		------  -----  -----  -------  -----  -----
+		 0.505  0.119  0.095    0.269  0.066  0.084
+	filter_rate (micro=0.611, macro=0.81):
+		  Stub      C     GA    Start     FA      B
+		------  -----  -----  -------  -----  -----
+		 0.495  0.881  0.905    0.731  0.934  0.916
+	recall (micro=0.749, macro=0.631):
+		  Stub      C     GA    Start     FA      B
+		------  -----  -----  -------  -----  -----
+		 0.855  0.497  0.637    0.643  0.762  0.391
+	!recall (micro=0.944, macro=0.926):
+		  Stub      C     GA    Start     FA      B
+		------  -----  -----  -------  -----  -----
+		  0.97  0.903  0.911    0.908  0.936  0.927
 	precision (micro=0.828, macro=0.371):
-		  FA      C    Start     GA    Stub     B
-		----  -----  -------  -----  ------  ----
-		0.03  0.226    0.769  0.064   0.974  0.16
-	!precision (micro=0.846, macro=0.935):
-		   FA      C    Start     GA    Stub      B
-		-----  -----  -------  -----  ------  -----
-		0.999  0.969    0.842  0.996   0.825  0.977
-	f1 (micro=0.774, macro=0.387):
-		   FA     C    Start     GA    Stub      B
-		-----  ----  -------  -----  ------  -----
-		0.058  0.31      0.7  0.116   0.907  0.228
-	!f1 (micro=0.891, macro=0.928):
-		   FA      C    Start     GA    Stub      B
-		-----  -----  -------  -----  ------  -----
-		0.966  0.935    0.874  0.951   0.891  0.951
-	accuracy (micro=0.874, macro=0.892):
-		   FA      C    Start     GA    Stub      B
-		-----  -----  -------  -----  ------  -----
-		0.935  0.881    0.822  0.906     0.9  0.907
-	fpr (micro=0.056, macro=0.075):
-		   FA      C    Start     GA    Stub      B
-		-----  -----  -------  -----  ------  -----
-		0.064  0.097    0.092  0.091   0.031  0.074
-	roc_auc (micro=0.941, macro=0.905):
-		   FA      C    Start     GA    Stub      B
-		-----  -----  -------  -----  ------  -----
-		0.954  0.855    0.903  0.908   0.978  0.831
-	pr_auc (micro=0.84, macro=0.399):
-		   FA      C    Start     GA    Stub      B
-		-----  -----  -------  -----  ------  -----
-		0.076  0.249    0.783  0.133   0.983  0.172
+		  Stub      C     GA    Start     FA     B
+		------  -----  -----  -------  -----  ----
+		 0.975  0.228  0.066    0.769  0.031  0.16
+	!precision (micro=0.849, macro=0.936):
+		  Stub      C     GA    Start     FA      B
+		------  -----  -----  -------  -----  -----
+		 0.831  0.969  0.996    0.843  0.999  0.977
+	f1 (micro=0.777, macro=0.388):
+		  Stub      C    GA    Start     FA      B
+		------  -----  ----  -------  -----  -----
+		 0.911  0.313  0.12    0.701  0.059  0.227
+	!f1 (micro=0.893, macro=0.929):
+		  Stub      C     GA    Start     FA      B
+		------  -----  -----  -------  -----  -----
+		 0.895  0.935  0.951    0.874  0.967  0.951
+	accuracy (micro=0.877, macro=0.893):
+		  Stub      C     GA    Start     FA      B
+		------  -----  -----  -------  -----  -----
+		 0.904  0.881  0.908    0.823  0.936  0.908
+	fpr (micro=0.056, macro=0.074):
+		  Stub      C     GA    Start     FA      B
+		------  -----  -----  -------  -----  -----
+		  0.03  0.097  0.089    0.092  0.064  0.073
+	roc_auc (micro=0.942, macro=0.906):
+		  Stub      C    GA    Start     FA      B
+		------  -----  ----  -------  -----  -----
+		 0.978  0.856  0.91    0.904  0.954  0.832
+	pr_auc (micro=0.841, macro=0.401):
+		  Stub      C     GA    Start     FA      B
+		------  -----  -----  -------  -----  -----
+		 0.983  0.251  0.134    0.787  0.075  0.174
 	
-	 - score_schema: {'type': 'object', 'properties': {'prediction': {'description': 'The most likely label predicted by the estimator', 'type': 'string'}, 'probability': {'description': 'A mapping of probabilities onto each of the potential output labels', 'type': 'object', 'properties': {'FA': {'type': 'number'}, 'C': {'type': 'number'}, 'Start': {'type': 'number'}, 'GA': {'type': 'number'}, 'Stub': {'type': 'number'}, 'B': {'type': 'number'}}}}, 'title': 'Scikit learn-based classifier score with probability'}
+	 - score_schema: {'properties': {'probability': {'properties': {'Stub': {'type': 'number'}, 'C': {'type': 'number'}, 'GA': {'type': 'number'}, 'Start': {'type': 'number'}, 'FA': {'type': 'number'}, 'B': {'type': 'number'}}, 'type': 'object', 'description': 'A mapping of probabilities onto each of the potential output labels'}, 'prediction': {'type': 'string', 'description': 'The most likely label predicted by the estimator'}}, 'title': 'Scikit learn-based classifier score with probability', 'type': 'object'}
 

--- a/models/enwiki.nettrom_wp10.gradient_boosting.model
+++ b/models/enwiki.nettrom_wp10.gradient_boosting.model
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5402a6e561106735150b35b475cc38caacd42961f280361d2eee83a064e4dcc3
-size 43983655
+oid sha256:0f0ed46734bcbd2a5956e099e9400246d6fb37e1a9df4d9ff1d7b7a9d56ccca0
+size 44127309


### PR DESCRIPTION
```
$ python
Python 3.5.3 (default, Sep 27 2018, 17:25:39) 
[GCC 6.3.0 20170516] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from revscoring import Model
>>> from revscoring.extractors import api
>>> import mwapi
>>> extractor = api.Extractor(mwapi.Session("https://en.wikipedia.org"))
Sending requests with default User-Agent.  Set 'user_agent' on mwapi.Session to quiet this message.
>>> model = Model.load(open("models/enwiki.nettrom_wp10.gradient_boosting.model"))
>>> feature_vals = list(extractor.extract(902872698, model.features))
>>> for name, val in zip(model.features, feature_vals):
...     print(name, val)
... 
feature.wikitext.revision.chars 73884.0
feature.wikitext.revision.content_chars 37521.0
feature.wikitext.revision.ref_tags 4.0
feature.(wikitext.revision.ref_tags / max(wikitext.revision.content_chars, 1)) 0.0001066069667652781
feature.wikitext.revision.wikilinks 311.0
feature.(wikitext.revision.wikilinks / max(wikitext.revision.content_chars, 1)) 0.008288691666000374
feature.wikitext.revision.external_links 57.0
feature.(wikitext.revision.external_links / max(wikitext.revision.content_chars, 1)) 0.001519149276405213
feature.wikitext.revision.headings_by_level(2) 13.0
feature.(wikitext.revision.headings_by_level(2) / max(wikitext.revision.content_chars, 1)) 0.0003464726419871539
feature.wikitext.revision.headings_by_level(3) 7.0
feature.(wikitext.revision.headings_by_level(3) / max(wikitext.revision.content_chars, 1)) 0.0001865621918392367
feature.enwiki.revision.image_links 9.0
feature.(enwiki.revision.image_links / max(wikitext.revision.content_chars, 1)) 0.00023986567522187575
feature.enwiki.revision.category_links 8.0
feature.(enwiki.revision.category_links / max(wikitext.revision.content_chars, 1)) 0.0002132139335305562
feature.(enwiki.revision.shortened_footnote_templates + wikitext.revision.ref_tags) 135.0
feature.((enwiki.revision.shortened_footnote_templates + wikitext.revision.ref_tags) / max(wikitext.revision.content_chars, 1)) 0.003597985128328136
feature.(enwiki.revision.cite_templates + enwiki.revision.shortened_footnote_templates) 269.0
feature.((enwiki.revision.cite_templates + enwiki.revision.shortened_footnote_templates) / max(wikitext.revision.content_chars, 1)) 0.007169318514964953
feature.((enwiki.revision.cite_templates + enwiki.revision.shortened_footnote_templates) / max((enwiki.revision.shortened_footnote_templates + wikitext.revision.ref_tags), 1)) 1.9925925925925927
feature.max(((enwiki.revision.shortened_footnote_templates + wikitext.revision.ref_tags) - (enwiki.revision.cite_templates + enwiki.revision.shortened_footnote_templates)), 0) 0.0
feature.(max(((enwiki.revision.shortened_footnote_templates + wikitext.revision.ref_tags) - (enwiki.revision.cite_templates + enwiki.revision.shortened_footnote_templates)), 0) / max(wikitext.revision.content_chars, 1)) 0.0
feature.enwiki.revision.non_cite_templates 28.0
feature.(enwiki.revision.non_cite_templates / max(wikitext.revision.content_chars, 1)) 0.0007462487673569468
feature.enwiki.revision.infobox_templates 0.0
feature.(enwiki.revision.cn_templates + 1) 1.0
feature.(enwiki.revision.cn_templates / max(wikitext.revision.content_chars, 1)) 0.0
feature.(enwiki.revision.who_templates + 1) 1.0
feature.(enwiki.revision.who_templates / max(wikitext.revision.content_chars, 1)) 0.0
feature.enwiki.main_article_templates 0.0
feature.(enwiki.main_article_templates / max(wikitext.revision.content_chars, 1)) 0.0
feature.(english.stemmed.revision.stems_length / max(wikitext.revision.content_chars, 1)) 1.179819301191333
feature.log((enwiki.revision.paragraphs_without_refs_total_length + 1)) 11.199091048371514
feature.len(<datasource.english.words_to_watch.revision.matches>) 77.0
feature.(len(<datasource.english.words_to_watch.revision.matches>) / max(len(<datasource.wikitext.revision.words>), 1)) 0.008131798500369627
```