### PR TITLE
Release Automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,12 @@ addons:
     - myspell-fr
 
 # command to install dependencies
-install: 
+install:
   - pip install -r requirements.txt
   - python setup.py install
   - pip install codecov
   - pip install flake8
+  - pip install twine
   - python -m nltk.downloader stopwords
 
 script:
@@ -36,3 +37,9 @@ notifications:
     on_failure: change
     template:
       - "%{repository_slug}#%{build_number} (%{branch} - %{commit} : %{author}): %{message} %{build_url}"
+
+deploy:
+  provider: script
+  script: bash scripts/deploy.sh
+  on:
+    branch: master

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,1 @@
+python setup.py sdist bdist_wheel && twine upload dist/* --skip-existing --username $PYPI_USER --password $PYPI_PASS


### PR DESCRIPTION
This PR adds the ability to deploy releases to PyPI via TravisCI.

This is done using a script (deploy.sh) which will build the binary and wheels, and upload via twine whenever the version gets incremented.

PyPI Credentials will be stored as private environment variables on the TravisCI repo.

Task: https://phabricator.wikimedia.org/T229850