### PR TITLE
update outdated docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This library provides a set of utilities for performing automatic detection of
 assessment classes of Wikipedia articles.  For more information, see the full
-documentation at http://pythonhosted.org/wikiclass.
+documentation at https://articlequality.readthedocs.io .
 
 **Compatible with Python 3.x only.**  Sorry.
 


### PR DESCRIPTION
The readme still pointed to the old wikiclass docs, this PR updates the link to point to our new readthedocs link.