### PR TITLE
Fix misleading dataset filenames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -525,7 +525,7 @@ datasets/ptwiki.labelings.20200301.json:
 	  --debug > $@
 
 
-datasets/ptwiki.balanced_labelings.9k_2020.json: \
+datasets/ptwiki.balanced_labelings.7.2k_2020.json: \
 		datasets/ptwiki.labelings.20200301.json
 	( \
 	  grep -P '"wp10": "1"' $< | \
@@ -543,22 +543,22 @@ datasets/ptwiki.balanced_labelings.9k_2020.json: \
 	) | \
 	shuf > $@
 
-datasets/ptwiki.labeled_revisions.with_text.9k_2020.json: \
-		datasets/ptwiki.balanced_labelings.9k_2020.json
+datasets/ptwiki.labeled_revisions.with_text.7.2k_2020.json: \
+		datasets/ptwiki.balanced_labelings.7.2k_2020.json
 	cat $< | \
 	./utility fetch_text \
 	  --api-host=https://pt.wikipedia.org \
 	  --verbose > $@
 
-datasets/ptwiki.labeled_revisions.w_cache.9k_2020.json: \
-		datasets/ptwiki.labeled_revisions.with_text.9k_2020.json
+datasets/ptwiki.labeled_revisions.w_cache.7.2k_2020.json: \
+		datasets/ptwiki.labeled_revisions.with_text.7.2k_2020.json
 	cat $< | \
 	./utility extract_from_text \
 	  articlequality.feature_lists.ptwiki.wp10 \
 	  --verbose > $@
 
 tuning_reports/ptwiki.wp10.md: \
-		datasets/ptwiki.labeled_revisions.w_cache.9k_2020.json
+		datasets/ptwiki.labeled_revisions.w_cache.7.2k_2020.json
 	cat $< | \
 	revscoring tune \
 	  config/classifiers.params.yaml \
@@ -576,7 +576,7 @@ tuning_reports/ptwiki.wp10.md: \
 	  --debug > $@
 
 models/ptwiki.wp10.gradient_boosting.model: \
-		datasets/ptwiki.labeled_revisions.w_cache.9k_2020.json
+		datasets/ptwiki.labeled_revisions.w_cache.7.2k_2020.json
 	cat $< | \
 	revscoring cv_train \
 	  revscoring.scoring.models.GradientBoosting \


### PR DESCRIPTION
Follows up 2a6432efdbcfc5c8ff3f704cb9e78446c6a35dfe

For ptwiki.labelings.20200301.json, "5" is the least frequent label, 
with only 1224 ocurrences. As such, we restrict all six labels to only 
1200, and since 6*1200 = 7200 (!= 9000), change the filenames to reflect 
that.