### PR TITLE
Fix module names import type

### DIFF
--- a/articlequality/__init__.py
+++ b/articlequality/__init__.py
@@ -7,6 +7,9 @@ from .utilities.score import score
 from .about import (__author__, __author_email__, __description__, __name__,
                     __url__, __version__)
 
-__all__ = [Extractor, TemplateExtractor, extract_from_text, extract_labelings,
-           extract_text, fetch_text, score, __name__, __version__, __author__,
-           __author_email__, __description__, __url__]
+__all__ = [
+        'Extractor', 'TemplateExtractor', 'extract_from_text',
+        'extract_labelings', 'extract_text', 'fetch_text', 'score',
+        '__name__', '__version__', '__author__', '__author_email__',
+        '__description__', '__url__'
+]

--- a/articlequality/extractors/__init__.py
+++ b/articlequality/extractors/__init__.py
@@ -29,4 +29,4 @@ from .ruwiki import ruwiki
 from .svwiki import svwiki
 from .trwiki import trwiki
 
-__all__ = [enwiki, frwiki, ptwiki, ruwiki, svwiki, trwiki]
+__all__ = ['enwiki', 'frwiki', 'ptwiki', 'ruwiki', 'svwiki', 'trwiki']


### PR DESCRIPTION
There was a CI error on Travis related to the `__all__` var having a type mismatch.

`__all__` should be a list of strings, not objects or functions, otherwise it breaks module imports like:
`from articlequality.extractors import *`

https://docs.python.org/3/tutorial/modules.html#importing-from-a-package

