### PR TITLE
Split important languages to have their own feature

### DIFF
--- a/tests/feature_lists/test_wikidatawiki.py
+++ b/tests/feature_lists/test_wikidatawiki.py
@@ -31,6 +31,12 @@ def crab_nebula():
     crab_nebula = {
         'title': 'Q207436',
         'id': 'Q207436',
+        'labels': {
+            'en': {
+                'value': 'Crab Nebula',
+                'language': 'en'
+            }
+        },
         'claims': {
             'P31': [
                 {
@@ -122,6 +128,30 @@ def test_has_commons_media(q7251, crab_nebula):
                  cache={entity: q7251}) is True
     assert solve(wikidatawiki.has_commons_media,
                  cache={entity: crab_nebula}) is False
+
+
+def test_important_languages(q7251, crab_nebula):
+    langs_count = len(wikidatawiki.IMPORTANT_LANG_CODES_LIST)
+    assert list(
+        solve(wikidatawiki.important_label_translation_features,
+              cache={entity: q7251})) == [True] * langs_count
+    assert list(
+        solve(wikidatawiki.important_description_translation_features,
+              cache={entity: q7251})) == [True] * langs_count
+    assert list(
+        solve(wikidatawiki.important_complete_translation_features,
+              cache={entity: q7251})) == [True] * langs_count
+
+    expected = [False, False, True, False, False, False, False, False]
+    assert list(
+        solve(wikidatawiki.important_label_translation_features,
+              cache={entity: crab_nebula})) == expected
+    assert list(
+        solve(wikidatawiki.important_description_translation_features,
+              cache={entity: crab_nebula})) == [False] * langs_count
+    assert list(
+        solve(wikidatawiki.important_complete_translation_features,
+              cache={entity: crab_nebula})) == [False] * langs_count
 
 
 def test_entity_parts(q7251):


### PR DESCRIPTION
Currently, if an item has 4 out of 10 important languages as label,
they'll get a feature like "4" which reduces the good predictors like
the difference between English and Chinese. With this change they get a
bigger set of features in a one-hot encoding way. For example
[0, 0, 1, 0, 1, 0, 1, 0, ...]

This increases number of correct predictions on the labelled dataset
from 4175 to 4198 (out of 4951).
![image](https://user-images.githubusercontent.com/5351225/88598898-aca7a480-d06a-11ea-9c73-a7c17c5e5f7f.png)
