### PR TITLE
Add is_scholarlyarticle feature to wikidatawiki

### DIFF
--- a/articlequality/feature_lists/wikidatawiki.py
+++ b/articlequality/feature_lists/wikidatawiki.py
@@ -32,6 +32,7 @@ class items:
     Mapping of english descriptions to item idenifiers
     """
     HUMAN = 'Q5'
+    SCHOLARLY_ARTICLE = 'Q13442814'
 
 
 def _process_references(entity):
@@ -153,9 +154,15 @@ has_birthday = wikibase_.revision.has_property(
 dead = wikibase_.revision.has_property(
     properties.DATE_OF_DEATH, name=name + '.revision.dead')
 is_blp = has_birthday.and_(not_(dead))
+is_scholarlyarticle = wikibase_.revision.has_property_value(
+    properties.INSTANCE_OF,
+    items.SCHOLARLY_ARTICLE,
+    name=name + '.revision.is_scholarlyarticle'
+)
 
 
 local_wiki = [
+    is_scholarlyarticle,
     is_human,
     is_blp,
     aggregators.len(complete_translations),


### PR DESCRIPTION
Scholarly articles have a different structure and often don't have many labels other than the one in the original language. This impacts them to a degree larger than what would be appropriate.

Note that this effect likely cannot be seen in the current training data was collected during a time when there were no scholarly articles and thus contains none.