### PR TITLE
Remove number of sitelinks signal from wikibase item quality model

### DIFF
--- a/articlequality/feature_lists/wikibase.py
+++ b/articlequality/feature_lists/wikibase.py
@@ -9,6 +9,5 @@ item = [
     log(wikibase.revision.qualifiers + 1),
     log(wikibase.revision.badges + 1),
     log(wikibase.revision.labels + 1),
-    log(wikibase.revision.sitelinks + 1),
     log(wikibase.revision.descriptions + 1)
 ]


### PR DESCRIPTION
Note: didn't create model binaries.

See: https://phabricator.wikimedia.org/T260768