### PR TITLE
Add check for image and commons media

### DIFF
--- a/articlequality/feature_lists/wikidatawiki.py
+++ b/articlequality/feature_lists/wikidatawiki.py
@@ -23,6 +23,7 @@ class properties:
     """
     Mapping of english descriptions to property identifiers
     """
+    IMAGE = 'P18'
     INSTANCE_OF = 'P31'
     DATE_OF_BIRTH = 'P569'
     DATE_OF_DEATH = 'P570'
@@ -70,6 +71,19 @@ def _process_external_identifiers(entity):
 external_identifiers = Datasource(
     name + ".revision.external_identifiers",
     _process_external_identifiers,
+    depends_on=[wikibase_.revision.datasources.entity])
+
+
+def _process_commons_media(entity):
+    for pid in entity.properties.keys():
+        if pid in property_datatypes.COMMONS_MEDIA:
+            return True
+    return False
+
+
+has_commons_media = Datasource(
+    name + ".revision.has_commons_media",
+    _process_commons_media,
     depends_on=[wikibase_.revision.datasources.entity])
 
 
@@ -227,6 +241,7 @@ has_birthday = wikibase_.revision.has_property(
 dead = wikibase_.revision.has_property(
     properties.DATE_OF_DEATH, name=name + '.revision.dead')
 is_blp = has_birthday.and_(not_(dead))
+
 is_scholarlyarticle = wikibase_.revision.has_property_value(
     properties.INSTANCE_OF,
     items.SCHOLARLY_ARTICLE,
@@ -237,6 +252,8 @@ is_astronomical_object = Feature(
     _process_is_astronomical_object,
     returns=bool,
     depends_on=[wikibase_.revision.datasources.entity])
+has_image = wikibase_.revision.has_property(
+    properties.IMAGE, name=name + '.revision.has_image')
 
 referenced_claims_ratio = Feature(
     name + '.revision.page.referenced_claims_ratio',
@@ -261,6 +278,8 @@ local_wiki = [
     is_astronomical_object,
     is_human,
     is_blp,
+    has_image,
+    has_commons_media,
     aggregators.len(complete_translations),
     aggregators.len(important_label_translations),
     aggregators.len(important_description_translations),

--- a/articlequality/feature_lists/wikidatawiki_data/property_datatypes.py
+++ b/articlequality/feature_lists/wikidatawiki_data/property_datatypes.py
@@ -3,14 +3,16 @@
 # To add/delete new properties from the `wikidatawiki.py` feature list we need
 # to manually update this file.
 
-# Currently the file contains a list of `NON_EXTERNAL_IDENTIFIERS` that we
-# want to extract as features. `NON_EXTERNAL_IDENTIFIERS` is used instead of
-# `EXTERNAL_IDENTIFIERS` because external identifiers comprise about 5000+ of
-# the total 8000+ currently on the database.
+# Currently the file contains a list of `NON_EXTERNAL_IDENTIFIERS` and
+# `COMMONS_MEDIA` that we want to extract as features.
+# `NON_EXTERNAL_IDENTIFIERS` is used instead of `EXTERNAL_IDENTIFIERS`
+# because external identifiers comprise about 5000+ of the total 8000+
+# properties currently on the database.
 # Using NON_EXTERNAL_IDENTIFIERS (~2500) reduces the processing time.
 
-# This list was obtained by making this query:
-# https://quarry.wmflabs.org/query/47645
+# This list was obtained by making these queries:
+# `NON_EXTERNAL_IDENTIFIERS`: https://quarry.wmflabs.org/query/47645
+# `COMMONS_MEDIA`: https://quarry.wmflabs.org/query/47836
 # and then doing a search and replace to format it as a python list.
 
 NONEXTERNAL_IDENTIFIERS = [
@@ -2577,3 +2579,69 @@ NONEXTERNAL_IDENTIFIERS = [
     'P7220',
     'P7221',
      'P8471']
+
+COMMONS_MEDIA = [
+    'P10',
+    'P14',
+    'P15',
+    'P18',
+    'P41',
+    'P51',
+    'P94',
+    'P109',
+    'P117',
+    'P154',
+    'P158',
+    'P181',
+    'P207',
+    'P242',
+    'P367',
+    'P368',
+    'P443',
+    'P491',
+    'P692',
+    'P948',
+    'P989',
+    'P990',
+    'P996',
+    'P1442',
+    'P1543',
+    'P1621',
+    'P1766',
+    'P1801',
+    'P1846',
+    'P1943',
+    'P1944',
+    'P2343',
+    'P2425',
+    'P2713',
+    'P2716',
+    'P2910',
+    'P2919',
+    'P3030',
+    'P3311',
+    'P3383',
+    'P3451',
+    'P4004',
+    'P4291',
+    'P4640',
+    'P4896',
+    'P5252',
+    'P5555',
+    'P5775',
+    'P5962',
+    'P6655',
+    'P6685',
+    'P6802',
+    'P7009',
+    'P7407',
+    'P7415',
+    'P7417',
+    'P7418',
+    'P7420',
+    'P7457',
+    'P8195',
+    'P8224',
+    'P8505',
+    'P8512',
+    'P8517']

--- a/tests/feature_lists/test_wikidatawiki.py
+++ b/tests/feature_lists/test_wikidatawiki.py
@@ -25,6 +25,38 @@ def q7251():
     return mwbase.Entity.from_json(json.loads(text))
 
 
+@pytest.fixture
+def crab_nebula():
+    crab_nebula = {
+        'title': 'Q207436',
+        'id': 'Q207436',
+        'claims': {
+            'P31': [
+                {
+                    'mainsnak': {
+                        'snaktype': 'value',
+                        'property': 'P31',
+                        'datavalue': {
+                            'value': {
+                                'entity-type': 'item',
+                                'numeric-id': 1931185,
+                                'id': 'Q1931185'
+                            },
+                            'type': 'wikibase-entityid'
+                        },
+                        'datatype': 'wikibase-item'
+                    },
+                    'type': 'statement',
+                    'id': 'Q10934$46D9E951-DD5A-4832-A2D2-DB0CE0425E0E',
+                    'rank': 'normal'
+                }
+            ]
+        }
+    }
+
+    return mwbase.Entity.from_json(crab_nebula)
+
+
 def test_item_completeness_empty():
     cache = {present_properties: {}, suggested_properties: {}}
 
@@ -59,36 +91,7 @@ def test_external_identifiers(q7251):
                  cache={entity: q7251}) == 79
 
 
-def test_is_astronomical_object(q7251):
-    crab_nebula = {
-        'title': 'Q207436',
-        'id': 'Q207436',
-        'claims': {
-            'P31': [
-                {
-                    'mainsnak': {
-                        'snaktype': 'value',
-                        'property': 'P31',
-                        'datavalue': {
-                            'value': {
-                                'entity-type': 'item',
-                                'numeric-id': 1931185,
-                                'id': 'Q1931185'
-                            },
-                            'type': 'wikibase-entityid'
-                        },
-                        'datatype': 'wikibase-item'
-                    },
-                    'type': 'statement',
-                    'id': 'Q10934$46D9E951-DD5A-4832-A2D2-DB0CE0425E0E',
-                    'rank': 'normal'
-                }
-            ]
-        }
-    }
-
-    crab_nebula = mwbase.Entity.from_json(crab_nebula)
-
+def test_is_astronomical_object(q7251, crab_nebula):
     assert solve(wikidatawiki.is_astronomical_object,
                  cache={entity: crab_nebula}) is True
     assert solve(wikidatawiki.is_astronomical_object,

--- a/tests/feature_lists/test_wikidatawiki.py
+++ b/tests/feature_lists/test_wikidatawiki.py
@@ -105,3 +105,16 @@ def test_references_ratio_features(q7251):
                  cache={entity: q7251}) == 0.2875
     assert solve(wikidatawiki.externally_referenced_claims_ratio,
                  cache={entity: q7251}) == 0.425
+
+
+def test_has_image(q7251, crab_nebula):
+    assert solve(wikidatawiki.has_image,
+                 cache={entity: q7251}) is True
+    assert solve(wikidatawiki.has_image,
+                 cache={entity: crab_nebula}) is False
+
+def test_has_commons_media(q7251, crab_nebula):
+    assert solve(wikidatawiki.has_commons_media,
+                 cache={entity: q7251}) is True
+    assert solve(wikidatawiki.has_commons_media,
+                 cache={entity: crab_nebula}) is False


### PR DESCRIPTION
Should improve accuracy of dump scoring which doesn't use property
suggester data. Maybe also of API scoring by giving higher weight to
images/media types.

TODO:
- having both image and commons media seems somewhat redundant?

Bug: T260771