### PR TITLE
 Add ratio-based references features 

### DIFF
--- a/tests/feature_lists/test_wikidatawiki.py
+++ b/tests/feature_lists/test_wikidatawiki.py
@@ -93,3 +93,12 @@ def test_is_astronomical_object(q7251):
                  cache={entity: crab_nebula}) is True
     assert solve(wikidatawiki.is_astronomical_object,
                  cache={entity: q7251}) is False
+
+
+def test_references_ratio_features(q7251):
+    assert solve(wikidatawiki.referenced_claims_ratio,
+                 cache={entity: q7251}) == 0.6
+    assert solve(wikidatawiki.wikimedia_referenced_ratio,
+                 cache={entity: q7251}) == 0.2875
+    assert solve(wikidatawiki.externally_referenced_claims_ratio,
+                 cache={entity: q7251}) == 0.425


### PR DESCRIPTION
These are useful in case of finding how many of statements have proper
references and if an item is properly referenced or not.

There's a feature that hold the total number of references but it's not
useful and I'm not sure the model combine it properly with the total
number of claims

(Note that this PR contains lots of commits that belongs to another PR (#505) I had to do it so it would not cause a rebase conflict with that.