### PR TITLE
Fix fatal error when creating the model info

### DIFF
--- a/articlequality/feature_lists/wikidatawiki.py
+++ b/articlequality/feature_lists/wikidatawiki.py
@@ -81,9 +81,10 @@ def _process_commons_media(entity):
     return False
 
 
-has_commons_media = Datasource(
+has_commons_media = Feature(
     name + ".revision.has_commons_media",
     _process_commons_media,
+    returns=bool,
     depends_on=[wikibase_.revision.datasources.entity])
 
 


### PR DESCRIPTION
This did not affect the actual training of the network, but it causes an fatal error in the last step when running `revscoring model_info`.

I thought I had taken care of that in #149, but apparently I must have missed it when squashing the changes and polishing that PR.