### PR TITLE
Fix extract_scores utility

### DIFF
--- a/articlequality/utilities/extract_scores.py
+++ b/articlequality/utilities/extract_scores.py
@@ -40,7 +40,7 @@ import mwtypes
 import mwtypes.files
 import mwxml
 import mysqltsv
-from revscoring import ScorerModel
+from revscoring import Model
 from revscoring.datasources import revision_oriented
 from revscoring.dependencies import solve
 
@@ -86,7 +86,7 @@ def main(argv=None):
 
     paths = args['<dump-file>']
     with open(args['--model']) as f:
-        model = ScorerModel.load(f)
+        model = Model.load(f)
 
     sunset = mwtypes.Timestamp(args['--sunset'])
 

--- a/articlequality/utilities/score.py
+++ b/articlequality/utilities/score.py
@@ -39,7 +39,7 @@ def score(scorer_model, text, cache=None, context=None):
     Scores a chunck of Wikitext markup
 
     :Parameters:
-        scorer_model : :class:`revscoring.ScorerModel`
+        scorer_model : :class:`revscoring.Model`
             A scorer model to apply
         text : `str`
             A chunk of Wikitext markup to score


### PR DESCRIPTION
ScorerModel has been deprecated and you need to use Model instead.
That's what has been done already in commits like
https://github.com/wikimedia/revscoring/commit/99cf055dc21bb6736b433b4602b538a30d6241be

Bug: T261330