### PR TITLE
Remove impactless property suggester feature

### DIFF
--- a/articlequality/feature_lists/wikidatawiki.py
+++ b/articlequality/feature_lists/wikidatawiki.py
@@ -1,6 +1,4 @@
 from revscoring import Feature
-from revscoring.datasources import \
-    revision_oriented as revision_oriented_datasources
 from revscoring.datasources.datasource import Datasource
 from revscoring.features import wikibase as wikibase_
 from revscoring.features import modifiers
@@ -227,27 +225,6 @@ def _process_externally_referenced_claims_ratio(entity):
     return externally_referenced_statements / max([len(statements), 1])
 
 
-def _process_item_completeness(current_properties, properties_suggested):
-    current_properties = set(current_properties.keys())
-
-    all_prob = 0.0
-    present_prob = 0.0
-    for statement in properties_suggested:
-        all_prob += float(statement['rating'])
-        if statement['id'] in current_properties:
-            present_prob += float(statement['rating'])
-
-    return present_prob / all_prob if all_prob else 0.0
-
-
-item_completeness = Feature(
-    name + '.revision.page.item_completeness',
-    _process_item_completeness,
-    returns=float,
-    depends_on=[
-        wikibase_.revision.datasources.properties,
-        revision_oriented_datasources.revision.page.suggested.properties])
-
 # Status
 is_human = wikibase_.revision.has_property_value(
     properties.INSTANCE_OF, items.HUMAN, name=name + '.revision.is_human')
@@ -326,7 +303,6 @@ local_wiki = \
         externally_referenced_claims_ratio,
         unique_references_count,
         unique_references_count / modifiers.max(references_count, 1),
-        item_completeness,
         aggregators.len(external_identifiers),
         non_external_id_statements_count
     ]

--- a/tests/feature_lists/test_wikidatawiki.py
+++ b/tests/feature_lists/test_wikidatawiki.py
@@ -3,8 +3,6 @@ import os
 
 import mwbase
 import pytest
-from revscoring.datasources import \
-    revision_oriented as revision_oriented_datasources
 from revscoring.dependencies import solve
 from revscoring.features import wikibase as wikibase_
 from revscoring.features.meta import aggregators
@@ -12,9 +10,6 @@ from revscoring.features.meta import aggregators
 from articlequality.feature_lists import wikidatawiki
 from articlequality.feature_lists.wikibase import item
 
-present_properties = wikibase_.revision.datasources.properties
-suggested_properties = \
-    revision_oriented_datasources.revision.page.suggested.properties
 entity = wikibase_.revision.datasources.entity
 
 
@@ -62,22 +57,6 @@ def crab_nebula():
     }
 
     return mwbase.Entity.from_json(crab_nebula)
-
-
-def test_item_completeness_empty():
-    cache = {present_properties: {}, suggested_properties: {}}
-
-    assert solve(wikidatawiki.item_completeness, cache=cache) == 0.0
-
-
-def test_item_completeness():
-    present = {'P123': {}, 'P234': {}}
-    suggested = [{'id': 'P123', 'rating': 0.8}, {'id': 'P404', 'rating': 0.6}]
-
-    cache = {present_properties: present, suggested_properties: suggested}
-    expected = 0.8 / (0.8 + 0.6)
-
-    assert solve(wikidatawiki.item_completeness, cache=cache) == expected
 
 
 def test_human_related_features(q7251):


### PR DESCRIPTION
It turned out, that this feature has significant effect on the scoring
of an item revision. And what slight effect it has seemed to be
minimally negative.
In addition it comes with significant drawbacks as it requires live
requests to the wikidata API during training and scoring via the API.
Those requests are too numerous while processing dumps, so they were
always skipped there. This meant that revisions could theoretically have
had a different score when scored via the API or based on dumps, which
is also undesirable.

After this is merged, the respective code can probably also be removed from revscoring.

Bug: https://phabricator.wikimedia.org/T261850